### PR TITLE
Handle RouterOS 7.18 empty API replies

### DIFF
--- a/src/mikrotik.html.ts
+++ b/src/mikrotik.html.ts
@@ -20,8 +20,8 @@ RED.nodes.registerType('mikrotik', {
     oneditprepare: function () {
         let node = this;
         $("#node-input-action").on('change', function () {
-            let cmd = node.command;
-            let newType = 'str';
+            let cmd: string = node.command;
+            let newType: string = 'str';
 
             const lookUp = ['/log/print', '/system/resource/print', '/interface/wireless/registration-table/print', '/system/reboot'];
             let value = parseInt($("#node-input-action").val() as string, 10);

--- a/src/mikrotik.ts
+++ b/src/mikrotik.ts
@@ -2,6 +2,28 @@ import { NodeAPI, Node, NodeMessageInFlow } from "node-red";
 import { MikrotikDeviceNode } from "./interfaces"
 
 import { RouterOSAPI } from "node-routeros";
+import { Channel } from "node-routeros/dist/Channel";
+
+function patchRouterOSEmptyReply() {
+    const channelPrototype = Channel.prototype as any;
+    if (channelPrototype.handlesRouterOSEmptyReply)
+        return;
+
+    const processPacket = channelPrototype.processPacket;
+    channelPrototype.processPacket = function (packet: string[]) {
+        // RouterOS 7.18 sends !empty before !done when a query has no records.
+        if (packet[0] === '!empty') {
+            packet.shift();
+            return;
+        }
+
+        return processPacket.call(this, packet);
+    };
+
+    channelPrototype.handlesRouterOSEmptyReply = true;
+}
+
+patchRouterOSEmptyReply();
 
 export = function (RED: NodeAPI) {
     function NodeMikrotik(this: Node, config: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
         "allowJs": false,
         "declaration": false,
         "sourceMap": false,
+        "skipLibCheck": true,
         "strict": false,
+        "rootDir": "./src",
         "outDir": "./nodes/",
     },
 


### PR DESCRIPTION
## Summary

- handle RouterOS 7.18 `!empty` API replies from `node-routeros` without treating them as unknown replies
- keep the command result as an empty payload array until the normal `!done` completion arrives
- fix TypeScript 6 build configuration and a narrow editor typing issue exposed while validating the build

## Root cause

RouterOS 7.18 introduced `!empty` replies for commands and queries that have no data to return. The pinned `node-routeros@1.6.9` parser predates that reply word, is the latest published npm version, and is marked discontinued, so it throws an unknown reply error before the wrapper can return an empty result.

## Validation

- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build`
- `/opt/homebrew/bin/node -e "const nodeModule = require('./nodes/mikrotik.js'); const { Channel } = require('node-routeros/dist/Channel'); const packet = ['!empty']; const context = { emit(event) { throw new Error('unexpected emit: ' + event); } }; Channel.prototype.processPacket.call(context, packet); if (packet.length !== 0) throw new Error('!empty packet was not consumed'); console.log('!empty smoke check passed');"`

Fixes #95